### PR TITLE
[AIM-2066] fixing problem with alias counting

### DIFF
--- a/juniper/src/validation/rules/limit_number_of_aliases.rs
+++ b/juniper/src/validation/rules/limit_number_of_aliases.rs
@@ -6,8 +6,8 @@ use crate::{
 };
 
 pub struct Aliases {
-    alias_count: u8,
-    max_allowed: u8,
+    alias_count: u32,
+    max_allowed: u32,
 }
 
 pub fn factory<'a>() -> Aliases {
@@ -107,28 +107,32 @@ mod tests {
 
     #[test]
     fn multiple_field_aliases_not_allowed() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
-            factory,
-            r#"
-        query MyQuery {
-            myField1: my_field,
-            myField2: my_field,
-            myField3: my_field,
-            myField4: my_field,
-            myField5: my_field
+        let mut query = String::from("query MyQuery {\n");
+        let mut expected_errors: Vec<RuleError> = Vec::new();
+        let mut current_error_index = 124;
+        let mut previous_line_length = 0;
+        for i in 1..=9999 {
+            let line = format!("            myField{}: my_field,\n", i);
+            let line_length = line.len();
+            query.push_str(&line);
+            // 3 aliases are allowed, so we ignore the first 3.
+            if i > 3 {
+                current_error_index += previous_line_length;
+                previous_line_length = line_length;
+                expected_errors.push(RuleError::new(
+                    &error_message(&format!("myField{}", i)),
+                    &[SourcePosition::new(
+                        current_error_index,
+                        i,
+                        12,
+                    )],
+                ));
+            }
+
         }
-        "#,
-            &[
-                RuleError::new(
-                    &error_message("myField4"),
-                    &[SourcePosition::new(133, 5, 12)],
-                ),
-                RuleError::new(
-                    &error_message("myField5"),
-                    &[SourcePosition::new(165, 6, 12)],
-                ),
-            ],
-        );
+        query.push_str("        }\n");
+
+        expect_fails_rule::<_, _, DefaultScalarValue>(factory, &query, &expected_errors);
     }
 
     #[test]


### PR DESCRIPTION
When investigating why we keep having problems with the API Consumers choking when receiving request with lots of aliases, I noticed a major bug in the alias counting, which was the fact that since the number of aliases was defined as an unsigned 8-bit integer, it was overflowing whenever reaching the max value. Therefore, this logic:
```rust
            self.alias_count += 1;
            if self.alias_count > self.max_allowed {
                ctx.report_error(&error_message(&alias.item), &[alias.start]);
            }
```
did not block all aliases from being executed if there were more than 255 aliases. Once it sees the 256th alias, there is an overflow and the count goes back to 0, and therefore it allows the next 4 aliases (from 0 to 3, all are less than or equal to the max_allowed, which is 3). So for 9999 aliases, instead of only allowing 3, it allows more than 100 queries to go through.

As for why the overflow was not caught, no tests existed that tried to go beyond 255 aliases. There is no overflow check when compiling in release mode, so in production we never got an error, the overflow simply happened without us noticing it.

But I did confirm this behavior by looking at the logs of the attack the Security Team performed on staging:

RuleError { locations: [SourcePosition { index: 20188, line: 254, col: 4 }], message: "Illegal number of aliases, **a253** is not allowed" },
RuleError { locations: [SourcePosition { index: 20268, line: 255, col: 4 }], message: "Illegal number of aliases, **a254** is not allowed" },
RuleError { locations: [SourcePosition { index: 20668, line: 260, col: 4 }], message: "Illegal number of aliases, **a259** is not allowed" },
(formatting done by me to make it easier to parse it)

Notice how a255, a256, a257 and a258 were not included in the error message.

The fix was to simply change the u8 to a u32. I imagine that there's no way to include 2**32 aliases since that would most likely go beyond what our server would even accept in the payload, although I have not really verified this, and HTTP does not by design define a limit for the payload size.